### PR TITLE
Exchange Targeting isset vs is_null

### DIFF
--- a/src/PaperG/FirehoundBlob/CampaignData/ExchangeTargeting.php
+++ b/src/PaperG/FirehoundBlob/CampaignData/ExchangeTargeting.php
@@ -37,8 +37,8 @@ class ExchangeTargeting
 
     public static function fromAssociativeArray($exchangeTargeting)
     {
-        $appnexus = !is_null($exchangeTargeting[self::APPNEXUS]) ? $exchangeTargeting[self::APPNEXUS] : null;
-        $facebook = !is_null($exchangeTargeting[self::FACEBOOK]) ? $exchangeTargeting[self::FACEBOOK] : null;
+        $appnexus = isset($exchangeTargeting[self::APPNEXUS]) ? $exchangeTargeting[self::APPNEXUS] : null;
+        $facebook = isset($exchangeTargeting[self::FACEBOOK]) ? $exchangeTargeting[self::FACEBOOK] : null;
 
         $exchangeTargeting = new ExchangeTargeting($appnexus, $facebook);
 


### PR DESCRIPTION
is_null is not a special method, so if you check is_null on an array index that
doesn't exist, you get an error.