### PR TITLE
Added a link to the FH docs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # firehound-blob
 This is the respository to keep track of the FirehoundBlob Library
+
+Documentation: [here](https://paperg.atlassian.net/wiki/display/FIR/Firehound+-+Simplified+Blob)


### PR DESCRIPTION
This commit updates the readme to link to our Simplified Blob documentation.