### PR TITLE
Add submission date to context

### DIFF
--- a/src/PaperG/FirehoundBlob/CampaignData/Context.php
+++ b/src/PaperG/FirehoundBlob/CampaignData/Context.php
@@ -35,6 +35,9 @@ class Context
 
     CONST APPNEXUS_VALUES           = "appnexusValues"; //this is a PaperG\PlaceLocal\API\AppNexus\ExchangeCampaign
 
+    // Value used for ramping
+    CONST SUBMISSION_DATE           = "submissionDate";
+
     public function __construct($values = Array())
     {
         $this->values = $values;
@@ -274,5 +277,15 @@ class Context
     public function setFacebookContext($facebookContext)
     {
         self::setValueByKey(self::FACEBOOK_CONTEXT, $facebookContext);
+    }
+
+    public function getSubmissionDate()
+    {
+        return self::getValueByKey(self::SUBMISSION_DATE);
+    }
+
+    public function setSubmissionDate($submissionDate)
+    {
+        self::setValueByKey(self::SUBMISSION_DATE, $submissionDate);
     }
 }


### PR DESCRIPTION
Adding submission date into context for ramping purposes. Previously we tried to infer a campaign's submission date from the dynamodb entry, but that proved to be highly inaccurate.