### PR TITLE
Remove Message Requirement For Creative

### DIFF
--- a/src/PaperG/FirehoundBlob/CampaignData/Creative.php
+++ b/src/PaperG/FirehoundBlob/CampaignData/Creative.php
@@ -123,7 +123,7 @@ class Creative
     {
         return isset($this->adtagJavascriptSecure) || isset($this->adtagJavascriptInsecure)
             || isset($this->adtagIframeSecure) || isset($this->adtagIframeInsecure)
-            || (isset($this->mediaUrl) && isset($this->message));
+            || isset($this->mediaUrl);
     }
 
     /**


### PR DESCRIPTION
This commit removes the message field requirement for Creative.php,
so only having a media url will validate a creative.

PL-20348