### PR TITLE
Rename FacebookBlob to UnmanagedFacebookBlob

### DIFF
--- a/src/PaperG/FirehoundBlob/Facebook/UnmanagedFacebookBlob.php
+++ b/src/PaperG/FirehoundBlob/Facebook/UnmanagedFacebookBlob.php
@@ -15,7 +15,7 @@ use PaperG\FirehoundBlob\Facebook\Targeting\FacebookDemographicTargeting;
 use PaperG\FirehoundBlob\Facebook\Targeting\FacebookGeographicTargeting;
 use PaperG\FirehoundBlob\Utility;
 
-class FacebookBlob implements BlobInterface
+class UnmanagedFacebookBlob implements BlobInterface
 {
     use Utility;
 

--- a/src/PaperG/FirehoundBlob/ScenarioBlob.php
+++ b/src/PaperG/FirehoundBlob/ScenarioBlob.php
@@ -3,7 +3,7 @@
 namespace PaperG\FirehoundBlob;
 
 
-use PaperG\FirehoundBlob\Facebook\FacebookBlob;
+use PaperG\FirehoundBlob\Facebook\UnmanagedFacebookBlob;
 
 class ScenarioBlob implements BlobInterface
 {
@@ -68,7 +68,7 @@ class ScenarioBlob implements BlobInterface
         $blobArray = $this->safeGet($array, self::BLOB);
         switch ($scenario) {
             case Scenario::FB_UNMANAGED:
-                $this->blob = new FacebookBlob($blobArray);
+                $this->blob = new UnmanagedFacebookBlob($blobArray);
                 break;
             default:
                 break;

--- a/test/phpunit/src/PaperG/FirehoundBlob/Facebook/UnmanagedFacebookBlobTest.php
+++ b/test/phpunit/src/PaperG/FirehoundBlob/Facebook/UnmanagedFacebookBlobTest.php
@@ -9,18 +9,18 @@
 namespace PaperG\Common\Test\Facebook;
 
 
-use PaperG\FirehoundBlob\Facebook\FacebookBlob;
+use PaperG\FirehoundBlob\Facebook\UnmanagedFacebookBlob;
 
-class FacebookBlobTest extends \FirehoundBlobTestCase
+class UnmanagedFacebookBlobTest extends \FirehoundBlobTestCase
 {
     /**
-     * @var FacebookBlob
+     * @var UnmanagedFacebookBlob
      */
     private $sut;
 
     public function setUp()
     {
-        $this->sut = new FacebookBlob();
+        $this->sut = new UnmanagedFacebookBlob();
     }
 
     public function testToFromArray() {
@@ -41,7 +41,7 @@ class FacebookBlobTest extends \FirehoundBlobTestCase
 
         $array  = $this->sut->toArray();
 
-        $new = new FacebookBlob();
+        $new = new UnmanagedFacebookBlob();
         $new->fromArray($array);
 
         $this->assertEquals($this->sut, $new);


### PR DESCRIPTION
This commit corrects the name of FacebookBlob