### PR TITLE
Update creative type for Facebook

### DIFF
--- a/src/PaperG/FirehoundBlob/Facebook/FacebookCreative.php
+++ b/src/PaperG/FirehoundBlob/Facebook/FacebookCreative.php
@@ -20,6 +20,11 @@ class FacebookCreative implements BlobInterface
     const OBJECTS = 'objects';
     const VERSION = 'version';
 
+    const LINK_TYPE = 'link';
+    const CAROUSEL_TYPE = 'carousel';
+
+    public static $validAdTypes = [self::LINK_TYPE, self::CAROUSEL_TYPE];
+
     const CURRENT_VERSION = 1;
 
     /**
@@ -73,8 +78,8 @@ class FacebookCreative implements BlobInterface
     {
         $creativeData = $this->getObjects();
         $creativeType = $this->getType();
-
-        return !(empty($creativeType) || empty($creativeData));
+        
+        return !empty($creativeType) && !empty($creativeData) && in_array($creativeType, self::$validAdTypes);
     }
 
     /**

--- a/test/phpunit/src/PaperG/FirehoundBlob/Facebook/FacebookCreativeTest.php
+++ b/test/phpunit/src/PaperG/FirehoundBlob/Facebook/FacebookCreativeTest.php
@@ -32,4 +32,20 @@ class FacebookCreativeTest extends \FirehoundBlobTestCase
         $newObject = new FacebookCreative($array);
         $this->assertEquals($this->sut, $newObject);
     }
+
+    public function test_isValid_WithValidType_ReturnsTrue()
+    {
+        $dummyType = 'link';
+        $this->sut->setType($dummyType);
+        $this->sut->setObjects([1,2,3,4]);
+        $this->assertEquals(true, $this->sut->isValid());
+    }
+
+    public function test_isValid_WithInvalidType_ReturnsFalse()
+    {
+        $dummyType = 'some_link_no_one_knows';
+        $this->sut->setType($dummyType);
+        $this->sut->setObjects([1,2,3,4]);
+        $this->assertEquals(false, $this->sut->isValid());
+    }
 } 


### PR DESCRIPTION
There are two creative ad types: link and carousel. Updating the FacebookCreative class, and the corresponding unit tests.